### PR TITLE
issue #8: Userモデルの作成（weightカラムのみ）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 # config/routes.rb
 # Rails アプリケーションのルーティング（URL とコントローラーの紐付け）を設定するファイル
 Rails.application.routes.draw do
+  devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   # Defines the root path route ("/")
   # root "articles#index"

--- a/db/migrate/20260506060851_devise_create_users.rb
+++ b/db/migrate/20260506060851_devise_create_users.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# db/migrate/20260506060851_devise_create_users.rb
+# データベースに users テーブルを作成するためのマイグレーションファイル
+
+class DeviseCreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    # users テーブルを作成
+    create_table :users do |t|
+      ## Database authenticatable（メールアドレスとパスワードでログイン）
+      t.string :email,              null: false, default: "" # メールアドレス（必須、空文字がデフォルト）
+      t.string :encrypted_password, null: false, default: "" # 暗号化されたパスワード（必須、空文字がデフォルト）
+
+      ## Recoverable（パスワードリセット機能）
+      t.string   :reset_password_token # パスワードリセット用のトークン
+      t.datetime :reset_password_sent_at # パスワードリセットメールの送信日時
+
+      ## Rememberable（ログイン状態の保持）
+      t.datetime :remember_created_at # ログイン状態を保持した日時
+
+      ## 【追加】weight（カラム体重を保存）
+      t.decimal :weight, precision: 5, scale: 2 # 体重（整数部3桁、小数部2桁、例：999.99kg）
+
+      ## Trackable（ログイン履歴の追跡）※コメントアウト（使用しない）
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable（メール確認機能）※コメントアウト（使用しない）
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable（アカウントロック機能）※コメントアウト（使用しない）
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      t.timestamps null: false # created_at（作成日時）と updated_at（更新日時）を自動追加
+    end
+
+    # メールアドレスにユニークインデックスを追加（重複を防ぐ）
+    add_index :users, :email,                unique: true
+    # パスワードリセットトークンにユニークインデックスを追加（重複を防ぐ）
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_06_060851) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.decimal "weight", precision: 5, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Close #8

## 実装内容
- Devise を使って User モデルを作成
- weight カラム（decimal型）を追加
  - precision: 5（全体の桁数）
  - scale: 2（小数点以下の桁数）
- マイグレーションを実行
  - https://gyazo.com/63b61b555db3558277984bd6816ad24c
  - マイグレーションファイルに weight カラムを追加
    - https://gyazo.com/e743e3e8ceda111e3f494132c38f1426
    - https://gyazo.com/40b9fbfc3b64b6673c9237e57bbaa404

## 確認方法
- [x] `rails c` で User モデルが作成されていることを確認
  - https://gyazo.com/4f14b92423bc5ebce6a3e20c14886d4b
- [x]  `User.column_names` で weight カラムが含まれていることを確認
  - https://gyazo.com/68d92627c734654ddbfcde46250ea459
- [x] Devise によって自動的にルーティングが追加されているか確認
  - https://gyazo.com/2e39876f5e65db6557dd0c7852c8909a
- [x] サインアップ画面確認（http://localhost:3000/users/sign_up）
   - https://gyazo.com/6e34b5e9914135830e754081ce92180d
- [x] ログイン画面確認
   - http://localhost:3000/users/sign_in
   - https://gyazo.com/9fd4faa1fb6e08f521c1e7f3ca4d482d