### PR TITLE
feat: Issue #9 - ユーザー登録機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,27 @@
 # frozen_string_literal: true
+# 文字列を変更不可にしてメモリ効率を改善するRubyの機能
 
+# app/controllers/application_controller.rb
+# 【追加】このファイルのパスを示すコメント（全コントローラーの基底クラス）
+
+# ApplicationController クラスの定義（全コントローラーの親クラス）
 class ApplicationController < ActionController::Base
+  # Deviseのコントローラーが呼ばれる前に configure_permitted_parameters メソッドを実行
+  # if: :devise_controller? で Devise のコントローラーの場合のみ実行
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  # protected メソッド（このクラスと継承先のクラスからのみ呼び出せる）
+  protected
+
+  # Devise のストロングパラメーターを設定するメソッド
+  # セキュリティのため、許可されたパラメーターのみを受け取る
+  def configure_permitted_parameters
+    # サインアップ時に weight パラメーターを許可
+    # permit(:sign_up, keys: [:weight]) で weight を受け取れるようにする
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:weight])
+    
+    # 【追加】アカウント更新時に weight パラメーターを許可
+    # permit(:account_update, keys: [:weight]) で weight を更新できるようにする
+    devise_parameter_sanitizer.permit(:account_update, keys: [:weight])
+  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <p><%= f.label :password, "New password" %></p>
+    <% if @minimum_password_length %>
+      <p><em>(<%= @minimum_password_length %> characters minimum)</em></p>
+    <% end %>
+    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
+  </div>
+
+  <div class="field">
+    <p><%= f.label :password_confirmation, "Confirm new password" %></p>
+    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me password reset instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,77 @@
+<%# app/views/devise/registrations/edit.html.erb %>
+<%# このファイルはDeviseのプロフィール編集画面のビューです %>
+
+<%# ページのタイトル %>
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%# プロフィール編集フォームの開始 %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  
+  <%# エラーメッセージを表示 %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <%# メールアドレス入力欄 %>
+  <div class="field">
+    <%# メールアドレスのラベル %>
+    <p><%= f.label :email %></p>
+    <%# メールアドレスの入力フィールド %>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <%#【変更】体重入力欄を追加 %>
+  <div class="field">
+    <%# 体重のラベル（「体重 (kg)」と表示） %>
+    <%= f.label :weight, "体重 (kg)" %><br />
+    <%# 体重の入力フィールド（数値専用） %>
+    <%# step: 0.1: 小数点第1位まで入力可能 %>
+    <%# placeholder: 入力欄に薄く表示されるヒント %>
+    <%= f.number_field :weight, step: 0.1, placeholder: "例: 65.5" %>
+  </div>
+
+  <%# パスワード変更欄（空欄の場合は変更しない） %>
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <%# 新しいパスワード入力欄 %>
+  <div class="field">
+    <%# パスワードのラベル %>
+    <p><%= f.label :password %> <i>(leave blank if you don't want to change it)</i></p>
+    <%# パスワードの入力フィールド %>
+    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
+    <% if @minimum_password_length %>
+      <p><em><%= @minimum_password_length %> characters minimum</em></p>
+    <% end %>
+  </div>
+
+  <%# 新しいパスワード確認入力欄 %>
+  <div class="field">
+    <%# パスワード確認のラベル %>
+    <p><%= f.label :password_confirmation %></p>
+    <%# パスワード確認の入力フィールド %>
+    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
+  </div>
+
+  <%# 現在のパスワード入力欄（変更を保存するために必要） %>
+  <div class="field">
+    <%# 現在のパスワードのラベル %>
+    <p><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i></p>
+    <%# 現在のパスワードの入力フィールド %>
+    <p><%= f.password_field :current_password, autocomplete: "current-password" %></p>
+  </div>
+
+  <%# 更新ボタン %>
+  <div class="actions">
+    <%# フォーム送信ボタン（「Update」と表示） %>
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<%# アカウント削除セクション %>
+<h3>Cancel my account</h3>
+
+<%# アカウント削除の説明 %>
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+
+<%# ログインページなどへのリンク %>
+<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,62 @@
+<%# app/views/devise/registrations/new.html.erb %>
+<%# このファイルはDeviseのユーザー登録画面のビューファイルです %>
+
+<%# ページのタイトル（見出し） %>
+<h2>Sign up</h2>
+
+<%# ユーザー登録フォームの開始 %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  
+  <%# バリデーションエラーを表示するパーシャルを呼び出す %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <%# メールアドレス入力欄 %>
+  <%# CSSのクラスを指定（スタイリング用） %>
+  <div class="field">
+    <%# メールアドレスのラベル（「Email」と表示される） %>
+    <p><%= f.label :email %></p>
+    <%# メールアドレスの入力フィールド %>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <%#【追加】体重入力欄 %>
+  <div class="field">
+    <%# 体重のラベル（「体重 (kg)」と表示）%>
+    <%= f.label :weight, "体重 (kg)" %><br />
+    <%# 体重の入力フィールド（小数点第1位まで入力可能）%>
+    <%= f.number_field :weight, step: 0.1, placeholder: "例: 65.5" %>
+  </div>
+
+  <%# パスワード入力欄 %>
+  <div class="field">
+    <%# パスワードのラベル（「Password」と表示） %>
+    <p><%= f.label :password %></p>
+    <%# パスワードの最小文字数を表示する条件分岐 %>
+    <%# @minimum_password_length: Deviseで設定された最小文字数（通常6文字） %>
+    <% if @minimum_password_length %>
+      <p><em>(<%= @minimum_password_length %> characters minimum)</em></p>
+    <% end %>
+    <%# パスワードの入力フィールド %>
+    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
+  </div>
+
+  <%# パスワード確認入力欄 %>
+  <div class="field">
+    <%# パスワード確認のラベル（「Password confirmation」と表示） %>
+    <p><%= f.label :password_confirmation %></p>
+    <%# パスワード確認の入力フィールド（パスワードと同じ値を入力） %>
+    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
+  </div>
+
+  <%# 登録ボタン %>
+   <%# CSSのクラスを指定（ボタンのスタイリング用） %>
+  <div class="actions">
+    <%# フォーム送信ボタン %>
+    <%= f.submit "Sign up" %>
+  </div>
+
+<%# フォーム終了 %>
+<% end %>
+
+<%# ログインページなどへのリンク %>
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <div class="field">
+    <p><%= f.label :password %></p>
+    <p><%= f.password_field :password, autocomplete: "current-password" %></p>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <p><%= f.check_box :remember_me %></p>
+      <p><%= f.label :remember_me %></p>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-temporary>
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <p><%= link_to "Log in", new_session_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <p><%= link_to "Sign up", new_registration_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <p><%= link_to "Forgot your password?", new_password_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <p><%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <p><%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <p><%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %></p>
+  <% end %>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>


### PR DESCRIPTION
## 概要
issue #9 の対応として、ユーザー登録機能に体重入力フィールドを追加しました。

## 変更内容
### 1. Deviseのビューを生成
- `docker compose run --rm web rails generate devise:views` を実行してDeviseのビューをカスタマイズ可能にしました
- https://gyazo.com/639246399c8b53a2208ae14ef4c6b186

### 2. ユーザー登録画面に体重入力フィールドを追加
- `app/views/devise/registrations/new.html.erb` に体重入力フィールドを追加
- `number_field` を使用し、小数点第1位まで入力可能に設定（`step: 0.1`）
- プレースホルダーで入力例を表示（例: 65.5）
- https://gyazo.com/c920e0c51703be22160005e5c814a4e9

### 3. ストロングパラメーターの設定
- `app/controllers/application_controller.rb` に `configure_permitted_parameters` メソッドを追加
- サインアップ時（`:sign_up`）に `weight` パラメーターを許可
- アカウント更新時（`:account_update`）に `weight` パラメーターを許可
- https://gyazo.com/124f2424c90f32c0948adc06eb2c6776

### 4. プロフィール編集画面に体重フィールドを追加
- `app/views/devise/registrations/edit.html.erb` に体重入力欄を追加
- https://gyazo.com/00f8953e037081b0020a5f1ece73f056

## 動作確認
### ユーザー登録画面での確認
- [x] ユーザー登録画面で体重を入力できることを確認
  - http://localhost:3000/users/sign_up
  - https://gyazo.com/c700e13a50c42f67eb500aeef7c1e056

### ユーザー登録の成功確認
- [x] ユーザー登録が成功することを確認
  - http://localhost:3000/
  - https://gyazo.com/231997eb91324fb5cb86d471d0643f4d

### データベースでの確認
- [x] Rails コンソールでデータが保存されていることを確認
  - https://gyazo.com/eac57e8edce62da31425085fddef772d

## 関連 issue
Closes #9