### PR TITLE
fix: sassc-rails を削除し、Tailwind CSS v2 の設定を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,13 +47,6 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Rails アプリケーションの起動を高速化するツール（キャッシュを使う）
 gem 'bootsnap', require: false
 
-# ===== Sass（CSS プリプロセッサ）=====
-# Sass で CSS を書くためのツール
-# - ネストした記述ができる
-# - 変数や関数が使える
-# - CSS を効率的に書ける
-gem 'sassc-rails'
-
 # ===== 認証機能（Devise）=====
 # ユーザー認証機能を提供する gem（ログイン、ログアウト、パスワードリセットなど）
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,6 @@ GEM
     erb (4.0.4)
       cgi (>= 0.3.3)
     erubi (1.13.1)
-    ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-arm64-darwin)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -268,14 +266,6 @@ GEM
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.32.0)
       base64 (~> 0.2)
@@ -299,7 +289,6 @@ GEM
     tailwindcss-rails (2.7.9-arm64-darwin)
       railties (>= 7.0.0)
     thor (1.5.0)
-    tilt (2.7.0)
     timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.12)
@@ -349,7 +338,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
-  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,9 +1,11 @@
-/* app/assets/stylesheets/application.scss */
-/* 【修正】Bootstrap を読み込む(もし使っている場合) */
+/* 【修正】app/assets/stylesheets/application.css */
+/* アプリケーション全体の CSS ファイル */
+
+/* 【修正】Bootstrap は使用していないためコメントアウト */
 /* @import "bootstrap"; */
 
-/* 【修正】top.scss を読み込む */
-@import "top";
+/* 【修正】top.css は自動的に読み込まれるため @import は不要 */
+/* Rails の Sprockets が自動的に app/assets/stylesheets 配下の CSS を読み込む */
 
 /* 【追加】ヘッダーのスタイル */
 .header {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -8,41 +8,37 @@
 /* Tailwind CSS のユーティリティクラスを読み込む */
 @tailwind utilities;
 
-/* 【追加】動的に使用するクラスを safelist として追加 */
+/* 動的に使用するクラスを safelist として追加 */
+/* Tailwind CSS v2 では @layer utilities の中で rgb() を使うと Sass と競合する */
+/* 【修正】そのため、16進数カラーコードに変更する */
 @layer utilities {
-  /* 【追加】灰色の背景 */
-  /* Sass 用にカンマ区切りに変更 */
+  /* 灰色の背景 */
   .bg-gray-300 {
-    background-color: rgb(209, 213, 219);
+    background-color: #d1d5db; /* rgb(209, 213, 219) を16進数に変換 */
   }
   
-  /* 【追加】灰色の背景(ホバー時) */
-  /* Sass 用にカンマ区切りに変更 */
+  /* 灰色の背景(ホバー時) */
   .hover\:bg-gray-400:hover {
-    background-color: rgb(156, 163, 175);
+    background-color: #9ca3af; /* rgb(156, 163, 175) を16進数に変換 */
   }
   
-  /* 【追加】灰色の文字 */
-  /* Sass 用にカンマ区切りに変更 */
+  /* 灰色の文字 */
   .text-gray-700 {
-    color: rgb(55, 65, 81);
+    color: #374151; /* rgb(55, 65, 81) を16進数に変換 */
   }
   
-  /* 【追加】緑色の背景 */
-  /* Sass 用にカンマ区切りに変更 */
+  /* 緑色の背景 */
   .bg-green-500 {
-    background-color: rgb(34, 197, 94);
+    background-color: #22c55e; /* rgb(34, 197, 94) を16進数に変換 */
   }
   
-  /* 【追加】緑色の背景(ホバー時) */
-  /* Sass 用にカンマ区切りに変更 */
+  /* 緑色の背景(ホバー時) */
   .hover\:bg-green-600:hover {
-    background-color: rgb(22, 163, 74);
+    background-color: #16a34a; /* rgb(22, 163, 74) を16進数に変換 */
   }
   
-  /* 【追加】白色の文字 */
-  /* Sass 用にカンマ区切りに変更 */
+  /* 白色の文字 */
   .text-white {
-    color: rgb(255, 255, 255);
+    color: #ffffff; /* rgb(255, 255, 255) を16進数に変換 */
   }
 }

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -1,4 +1,4 @@
-/* app/assets/stylesheets/top.scss */
+/* 【修正】app/assets/stylesheets/top.css */
 /* メインコンテンツ全体のスタイル */
 .top-wrapper {
   min-height: calc(100vh - 120px); /* ヘッダーとフッターを除いた高さ */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,11 +10,9 @@
     <%= csrf_meta_tags %>
     <!-- Content Security Policy を設定(セキュリティ対策) -->
     <%= csp_meta_tag %>
-    <!-- Tailwind CSS を読み込む -->
+    <!-- 【修正】Tailwind CSS を読み込む(1回だけ) -->
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-    <!-- アプリケーション固有の CSS を読み込む -->
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <!-- 【修正】アプリケーション固有の CSS を読み込む -->
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <!-- JavaScript ファイルを読み込む -->
     <%= javascript_importmap_tags %>


### PR DESCRIPTION
## 概要
Render でのデプロイエラーを解消するため、Sass ファイルを CSS に変換し、Tailwind CSS v2 のみに統一しました。

## 変更内容
- `application.scss` → `application.css` に変更
- `top.scss` → `top.css` に変更
- `application.html.erb` の `stylesheet_link_tag` の重複を削除
- `@import` 構文を削除し、Rails の Sprockets による自動読み込みに変更

## 動作確認
- [x] ローカル環境でエラーが解消されていることを確認
- [x] ヘッダーのスタイルが正しく適用されていることを確認
- [x] Flash メッセージのスタイルが正しく適用されていることを確認
- [x] トップページのスタイルが正しく適用されていることを確認
- [ ] 本番環境(Render)でエラーが解消されていることを確認