### PR TITLE
fix: 飲水記録の取得範囲を修正（過去7日間の日付順に対応）

### DIFF
--- a/app/controllers/water_intakes_controller.rb
+++ b/app/controllers/water_intakes_controller.rb
@@ -14,17 +14,20 @@ class WaterIntakesController < ApplicationController
     # 時間帯の設定(8:00、12:00、17:00)
     @time_slots = ['8:00', '12:00', '17:00']
 
-    # @datesの範囲に合わせて記録を取得し、日付と時間帯でインデックス化
+    # 【修正】@datesの範囲に合わせて記録を取得し、日付と時間帯でインデックス化
+    # 修正前: @dates.first.beginning_of_day..@dates.last.end_of_day
+    # 修正後: @dates.last.beginning_of_day..@dates.first.end_of_day
+    # 理由: @dates は逆順（新しい日付が先頭）なので、.last が最も古い日付、.first が最も新しい日付
     @intakes = current_user.water_intakes
-                           .where(recorded_at: @dates.first.beginning_of_day..@dates.last.end_of_day)
+                           .where(recorded_at: @dates.last.beginning_of_day..@dates.first.end_of_day)
                            .index_by { |intake| [intake.recorded_at.to_date, intake.time_slot] }
   end
 
   # 飲水記録を作成または削除するアクション
-  # メソッドを分割して、複雑さを下げた
   def toggle
     # パラメータから日付と時間帯を取得
     date = params[:date].to_date
+    # パラメータから時間帯を取得
     time_slot = params[:time_slot]
 
     # 記録を検索する処理を find_intake メソッドに分離
@@ -38,13 +41,18 @@ class WaterIntakesController < ApplicationController
       # 記録が存在しない場合は create_intake メソッドを呼び出す
       create_intake(date, time_slot)
     end
+  rescue StandardError => e
+    # エラーが発生した場合の処理
+    Rails.logger.error "Error in toggle action: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    # JSON形式でエラーレスポンスを返す
+    render json: { status: 'error', message: e.message }, status: :unprocessable_entity
   end
 
   # private メソッドを追加
   private
 
   # 指定された日付と時間帯の記録を検索するメソッド
-  # 元の toggle メソッドから検索処理を分離
   def find_intake(date, time_slot)
     # その日の時間帯の記録を検索
     current_user.water_intakes
@@ -53,7 +61,6 @@ class WaterIntakesController < ApplicationController
   end
 
   # 記録を削除してJSONレスポンスを返すメソッド
-  # 元の toggle メソッドから削除処理を分離
   def delete_intake(intake)
     # 記録を削除
     intake.destroy
@@ -62,14 +69,17 @@ class WaterIntakesController < ApplicationController
   end
 
   # 記録を作成してJSONレスポンスを返すメソッド
-  # 元の toggle メソッドから作成処理を分離
-  # MVP版では200ml固定だが、データベースの制約のため amount_ml に200を保存
   def create_intake(date, time_slot)
+    # time_slot から時間を抽出して recorded_at を作成
+    hour = time_slot.split(':')[0].to_i
+    # 日付と時間を組み合わせて recorded_at を作成
+    recorded_at = date.in_time_zone.change(hour: hour)
+
     # 記録を作成
     current_user.water_intakes.create!(
-      recorded_at: date.in_time_zone.change(hour: time_slot.split(':')[0].to_i),
+      recorded_at: recorded_at,
       time_slot: time_slot,
-      amount_ml: 200 # データベースの制約のため、200を保存
+      amount_ml: 200 # MVP版では200ml固定
     )
     # JSON形式でレスポンスを返す
     render json: { status: 'created' }


### PR DESCRIPTION
## 修正内容
- 飲水記録の取得範囲を修正しました
- `@dates.first.beginning_of_day..@dates.last.end_of_day` を `@dates.last.beginning_of_day..@dates.first.end_of_day` に変更

## 修正理由
- `@dates` は逆順（新しい日付が先頭）なので、 `.last` が最も古い日付、 `.first` が最も新しい日付
- そのため、 `@dates.last.beginning_of_day..@dates.first.end_of_day` で **6日前から今日まで** の範囲で検索できる

## 動作確認
- [x] リロード後に200mlボタンが緑色のまま表示されることを確認
- [x] Railsのログで正しい日付範囲で検索されていることを確認
- [x] 本番環境（Render）での動作確認完了