### PR TITLE
feat: Render PostgreSQLからNeon PostgreSQLへ移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# .gitignore
+# Gitによる追跡（管理）から除外したいファイルやディレクトリを指定するための設定ファイル
+
 # Ignore bundler config.
 /.bundle
 
@@ -32,3 +35,4 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+.env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.28.0)
     parser (3.3.11.1)
@@ -182,6 +184,7 @@ GEM
       racc
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -288,6 +291,8 @@ GEM
       railties (>= 7.0.0)
     tailwindcss-rails (2.7.9-arm64-darwin)
       railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -318,7 +323,8 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-24
+  arm64-darwin-24 
+  x86_64-linux
 
 DEPENDENCIES
   better_errors

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,5 @@
 # config/database.yml
+# アプリケーションとデータベースを接続するための設定ファイル
 # PostgreSQL. Versions 9.3 and up are supported.
 #
 # Install the pg driver:
@@ -100,3 +101,4 @@ test:
 production:
   <<: *default  # 上記のdefault設定を継承
   url: <%= ENV['DATABASE_URL'] %>  # 【変更】Renderが自動設定するDATABASE_URL環境変数を使用(host, username, password, databaseなどの情報がすべて含まれる)
+  prepared_statements: false # 【追加】データベース接続時に事前準備された命令を使わない（競合エラー予防）


### PR DESCRIPTION
# 概要
Render PostgreSQLの期限切れに伴い、Neon PostgreSQLへ変更を行いました。

# 環境設定

## Neon PostgreSQL
-  Neonでプロジェクトを新規作成
-  データベースを作成
-  **Connection Pooling** を有効化
-  **Pooling URL** を取得

**設定内容：**
- データベース名: `mizumo`
- Postgres version: 16

---

## Render
- Renderの環境変数に以下を設定

**環境変数：**
- `DATABASE_URL`: Neonの Pooling URL

**スクリーンショット（個人情報部分は非表示です）：**
![Renderの環境変数設定](https://gyazo.com/42f9c56f738a1bf361ef3fd47f1cf464.png)

---

# 変更内容

## 1. `.env` の作成
Neonデータベースへの接続情報を記載しました。

**スクリーンショット：**
![.envファイルの内容](https://gyazo.com/f4fce5e7d90b3b818ccddb9b27f2b7ae.png)

---

## 2. `.gitignore` の更新
機密情報をGit管理から除外し、セキュリティを確保するため、 `.env` を除外しました。

**スクリーンショット：**
![.gitignoreの更新内容](https://gyazo.com/2b1fd44e5d27dae2a26970f7f9ad40ea.png)

---

## 3. `config/database.yml` の更新
データベース接続時の中継ツール（PgBouncer）との相性問題を回避し、接続を安定させるための設定を追加しました。

**変更内容：**
- `prepared_statements: false` を追加
- `DATABASE_URL` 環境変数を使用するように変更

**スクリーンショット：**
![database.ymlの更新内容](https://gyazo.com/35c6f3db2000234dfb69e28a0cc00de7.png)

## 4. `Gemfile.lock` の更新
Gemfile.lock がRenderのプラットフォーム（x86_64-linux）（aarch64-linux）に対応していない状況であったため、追加しました。

**変更内容：**
- `bundle lock --add-platform x86_64-linux`を追加
- `bundle lock --add-platform aarch64-linux`を追加

**スクリーンショット：**
![ターミナルの更新内容](https://gyazo.com/9237964bedf151b9e6ce6ed3d43d5bae.png)
![Gemfile.lockの確認内容](https://gyazo.com/a0b3c729a8b5bf804da8dd34d5c00611.png)
---

# チェックリスト
- [x] Neonでデータベースを作成
- [x] Neonで **Connection Pooling** を有効化
- [x] Renderの環境変数に `DATABASE_URL` を設定
- [x] `.env` にNeonの接続情報を記載
- [x] `.gitignore` に `.env` を追加
- [x] `config/database.yml` を更新
- [x] ローカル環境で動作確認
- [x] 本番環境にデプロイ（マージ後に実施）

Closes #95