### PR TITLE
fix: Renderのドメインをホスト認証の許可リストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,6 +133,9 @@ Rails.application.configure do
 
   # Renderのホストを許可
   config.hosts << 'mizumo.onrender.com'
+  # 【追加】Renderのドメインを許可
+  config.hosts << "mizumo-db-neon.onrender.com"
+
 
   # 開発段階では全て許可（本番では削除推奨）
   # config.hosts.clear


### PR DESCRIPTION
# 概要
Renderのドメイン（mizumo-db-neon.onrender.com）を Rails 7 の Host Authorization の許可リストに追加しました。

## 背景
Rails 7 では、セキュリティ強化のため Host Authorization がデフォルトで有効になっています。
Renderのドメインが許可リストに含まれていなかったため、以下のエラーが発生していました。
`ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: mizumo-db-neon.onrender.com`

# 変更内容
- `config/environments/production.rb`に追加
  -Renderのドメインを追加
```ruby
# 【追加】Renderのドメインを許可
config.hosts << "mizumo-db-neon.onrender.com"
```
![ドメインを許可](https://gyazo.com/b5398fe382f01d8f80b2adb5c71a5c6a.png)

# 確認方法
- [x]  Renderのデプロイが成功する
- [x]  Renderのログにエラーが表示されない
- [x]  `https://mizumo-db-neon.onrender.com`にアクセスできる
- [x] ブラウザでトップページが正常に表示される

Closes #95