### PR TITLE
x86_64-linux プラットフォームを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,12 +173,15 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pg (1.6.3-aarch64-linux)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
@@ -286,6 +289,8 @@ GEM
     strscan (3.1.8)
     tailwindcss-rails (2.7.9-aarch64-linux)
       railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -316,6 +321,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   better_errors


### PR DESCRIPTION
## 概要
Render でのデプロイエラーを修正するため、`Gemfile.lock` に `x86_64-linux` プラットフォームを追加しました。

## 背景
Ruby 3.2.4 へのアップグレード後、Render でデプロイエラーが発生しました。
エラーメッセージから、プラットフォームの不一致が原因であることが分かりました。

## 変更内容
- `Gemfile.lock` に `x86_64-linux` プラットフォームを追加
- ![Gemfile.lock](https://gyazo.com/d7ff22cf2a587bddc3a652e1699e5bcb.png)

## 実行したコマンド
```bash
bundle lock --add-platform x86_64-linux
```
## 動作確認
- [x]  Renderのデプロイが成功する
　- ![デプロイ画面](https://gyazo.com/4d967c145c39fd7cc4cdfd6b8a25f346.png)

- [x]  `https://mizumo-db-neon.onrender.com`にアクセスできる
　- ![本番画面](https://gyazo.com/089f0e328a2bb2493c088f33826993ea.png)


closes #95