### PR TITLE
feat: ヘッダー・フッター・ボトムナビゲーションの実装

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -181,6 +183,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.3-aarch64-linux)
+    pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pp (0.6.4)
       prettyprint
@@ -289,6 +292,8 @@ GEM
     strscan (3.1.8)
     tailwindcss-rails (2.7.9-aarch64-linux)
       railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-arm64-darwin)
+      railties (>= 7.0.0)
     tailwindcss-rails (2.7.9-x86_64-linux)
       railties (>= 7.0.0)
     thor (1.5.0)
@@ -321,6 +326,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,4 +1,4 @@
-/* app/assets/stylesheets/application.tailwind.css */
+/* 【修正】app/assets/stylesheets/application.tailwind.css */
 /* Tailwind CSS の基本スタイルを読み込む */
 @tailwind base;
 
@@ -7,38 +7,3 @@
 
 /* Tailwind CSS のユーティリティクラスを読み込む */
 @tailwind utilities;
-
-/* 動的に使用するクラスを safelist として追加 */
-/* Tailwind CSS v2 では @layer utilities の中で rgb() を使うと Sass と競合する */
-/* 【修正】そのため、16進数カラーコードに変更する */
-@layer utilities {
-  /* 灰色の背景 */
-  .bg-gray-300 {
-    background-color: #d1d5db; /* rgb(209, 213, 219) を16進数に変換 */
-  }
-  
-  /* 灰色の背景(ホバー時) */
-  .hover\:bg-gray-400:hover {
-    background-color: #9ca3af; /* rgb(156, 163, 175) を16進数に変換 */
-  }
-  
-  /* 灰色の文字 */
-  .text-gray-700 {
-    color: #374151; /* rgb(55, 65, 81) を16進数に変換 */
-  }
-  
-  /* 緑色の背景 */
-  .bg-green-500 {
-    background-color: #22c55e; /* rgb(34, 197, 94) を16進数に変換 */
-  }
-  
-  /* 緑色の背景(ホバー時) */
-  .hover\:bg-green-600:hover {
-    background-color: #16a34a; /* rgb(22, 163, 74) を16進数に変換 */
-  }
-  
-  /* 白色の文字 */
-  .text-white {
-    color: #ffffff; /* rgb(255, 255, 255) を16進数に変換 */
-  }
-}

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# 【追加】app/controllers/calendars_controller.rb
+# カレンダー画面を表示するコントローラー
+class CalendarsController < ApplicationController
+  # Devise の認証機能を使用（ログインしていないユーザーはアクセス不可）
+  before_action :authenticate_user!
+
+  # カレンダー画面のトップページ
+  def index
+    # 現在は仮実装のため、特に処理は行わない
+    # 今後、カレンダー機能を実装する際にここに処理を追加する
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,25 +3,36 @@
 # app/controllers/static_pages_controller.rb
 # 静的ページ(トップページなど)を管理するコントローラー
 class StaticPagesController < ApplicationController
-  # トップページだけ認証をスキップ
-  skip_before_action :authenticate_user!, only: [:top]
+  # トップページ、問い合わせ、利用規約、プライバシーは認証をスキップ
+  skip_before_action :authenticate_user!, only: %i[top terms privacy contact]
 
   # トップページを表示するアクション
   def top
     # ログイン状態かどうかを確認
     return unless user_signed_in?
 
-    # 【修正】リファラー(参照元)を取得
+    # リファラー(参照元)を取得
     referer = request.referer
 
-    # 【修正】リファラーが存在しない、または外部サイトからのアクセスの場合
-    # (ブラウザを閉じて直接アクセスした場合など)
-    return unless referer.blank? || !referer.start_with?(request.base_url)
+    # 【修正】リファラーが存在し、かつ自サイトからのアクセスの場合は何もしない
+    return if referer.present? && referer.start_with?(request.base_url)
 
-    # 記録ページにリダイレクト
+    # 【修正】それ以外の場合は記録ページにリダイレクト
     redirect_to water_intakes_path
+  end
 
-    # 【修正】リファラーが存在する場合(ヘッダーのトップページボタンから来た場合など)
-    # トップページを表示(何もしない)
+  # 【修正】利用規約ページ
+  def terms
+    # 利用規約ページを表示
+  end
+
+  # 【修正】プライバシーポリシーページ
+  def privacy
+    # プライバシーポリシーページを表示
+  end
+
+  # 【修正】問い合わせページ
+  def contact
+    # 問い合わせページを表示
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@
 # ApplicationHelper モジュールを定義
 # アプリケーション全体で使えるヘルパーメソッドをまとめる場所
 module ApplicationHelper
-  # 【変更】 Flash メッセージのタイプを Bootstrap のクラス名に変換するメソッド
+  # Flash メッセージのタイプを Bootstrap のクラス名に変換するメソッド
   # 引数: flash_type（例: 'notice', 'alert' など）
   # 戻り値: Bootstrap のクラス名（例: 'success', 'danger' など）
   def bootstrap_class_for(flash_type)
@@ -29,12 +29,26 @@ module ApplicationHelper
     end
   end
 
-  # 【変更】ページタイトルを動的に設定するメソッド
+  # ページタイトルを動的に設定するメソッド
   # 引数: page_title(ページごとのタイトル、デフォルトは nil)
   # 戻り値: ページタイトル（例: 'ログイン | ミズモ' または 'ミズモ'）
   def page_title(page_title = nil)
     base_title = 'ミズモ' # アプリケーション名
     # page_title が存在する場合は「ページタイトル | ミズモ」、存在しない場合は「ミズモ」のみを返す
     page_title.present? ? "#{page_title} | #{base_title}" : base_title
+  end
+
+  # 【追加】ボトムナビゲーションを表示するかどうかを判定するメソッド
+  # 戻り値: true(表示する) / false(表示しない)
+  def show_bottom_navigation?
+    # ログイン中の場合は常に表示
+    return true if user_signed_in?
+
+    # 【修正】ログイン前の場合、特定のページでのみ表示
+    # - ホーム画面(トップページ): static_pages#top
+    # - お問い合わせ画面: static_pages#contact
+    # - 利用規約画面: static_pages#terms
+    # - プライバシーポリシー画面: static_pages#privacy
+    controller_name == 'static_pages' && %w[top contact terms privacy].include?(action_name)
   end
 end

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,0 +1,11 @@
+<%# 【追加】app/views/calendars/index.html.erb %>
+<%# カレンダー画面（仮実装） %>
+
+<%# コンテナ: 中央寄せ、左右の余白、上の余白 %>
+<div class="container mx-auto px-4 pt-8">
+  <%# 見出し: テキストサイズ大、太字、グレー色、下に余白 %>
+  <h1 class="text-3xl font-bold text-gray-800 mb-6">カレンダー</h1>
+  
+  <%# 仮実装のメッセージ %>
+  <p class="text-gray-600">カレンダー機能は現在開発中です。</p>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,5 @@
-<!-- 【修正】app/views/devise/sessions/new.html.erb -->
+<!-- app/views/devise/sessions/new.html.erb -->
+<!-- 会員登録済みのユーザーが、メールアドレスとパスワードを入力して「ログインするための画面」 -->
 
 <!-- タイトルを i18n で日本語化 -->
 <h2><%= t('.title') %></h2>
@@ -22,7 +23,7 @@
     <p><%= f.password_field :password, autocomplete: "current-password" %></p>
   </div>
 
-  <!-- 【削除】「ログイン状態を保持する」チェックボックスを削除 -->
+  <!-- 【コメントアウト中】「ログイン状態を保持する」チェックボックスを削除 -->
   <%# if devise_mapping.rememberable? %>
     <%# <div class="field"> %>
       <%# チェックボックス %>
@@ -39,5 +40,5 @@
   </div>
 <% end %>
 
-<!-- 「パスワードを忘れた」「新規登録」などのリンク -->
+<!--「パスワードを忘れた」「新規登録」などのリンク -->
 <%= render "devise/shared/links" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,5 @@
 <!-- app/views/layouts/application.html.erb -->
+<!-- Webサイト全体の共通テンプレート(ひな形) -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,7 +11,7 @@
     <%= csrf_meta_tags %>
     <!-- Content Security Policy を設定(セキュリティ対策) -->
     <%= csp_meta_tag %>
-    <!-- Tailwind CSS を読み込む(1回だけ) -->
+    <!-- Tailwind CSS を読み込む -->
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <!-- アプリケーション固有の CSS を読み込む -->
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
@@ -18,68 +19,285 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <!-- ヘッダー全体を bg-white と shadow で装飾 -->
-    <header class="bg-white shadow">
-      <!-- container で中央寄せ、px-4 で左右の余白、py-4 で上下の余白、flex で横並び、justify-between で左右に配置、items-center で縦方向中央揃え -->
-      <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+  <!-- body タグに背景色とテキスト色を設定 -->
+  <body class="bg-ivory text-charcoal">
+    <!-- ヘッダー全体(背景色、テキスト色、影を設定) -->
+    <header class="bg-brand-navy text-pure-white shadow-lg">
+      <!-- コンテナで中央寄せ、余白設定、横並び配置 -->
+      <div class="container mx-auto px-6 py-4 flex justify-between items-center">
         
-        <!-- 【修正】ロゴ「ミズモ」を左側に表示（全ページで表示、クリックでトップページに遷移） -->
+        <!-- ロゴ「ミズモ」を左側に表示(クリックでトップページに遷移) -->
         <h1 class="text-2xl font-bold">
-          <%= link_to 'ミズモ', root_path, class: 'text-blue-600 hover:text-blue-700' %>
+          <%= link_to 'ミズモ', root_path, class: 'text-pure-white hover:text-brand-orange transition duration-200' %>
         </h1>
         
-        <!-- ヘッダー右側のボタン群を flex で横並び、space-x-4 でボタン間に余白、items-center で縦方向中央揃え -->
+        <!-- ヘッダー右側のボタン群(横並び、ボタン間に余白、縦方向中央揃え) -->
         <div class="flex items-center space-x-4">
           
-          <!-- 【修正】トップページの場合 -->
-          <% if controller_name == 'static_pages' && action_name == 'top' %>
-            <!-- 【修正】ログイン状態で表示を出し分ける -->
+          <!-- トップページの場合 -->
+          <% if controller_path == 'static_pages' && action_name == 'top' %>
             <% if user_signed_in? %>
-              <!-- 【修正】ログイン中の場合は「記録」「設定」「ログアウト」ボタンを表示 -->
-              <%= link_to '記録', water_intakes_path, class: 'inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition duration-200' %>
-              <%= link_to '設定', edit_user_registration_path, class: 'inline-block px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white font-semibold rounded transition duration-200' %>
-              <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, form_class: 'inline-block', class: 'px-4 py-2 bg-red-500 hover:bg-red-600 text-white font-semibold rounded transition duration-200 cursor-pointer' %>
+              <!-- ログイン中の場合は「ログアウト」ボタンのみ表示 -->
+              <%= button_to destroy_user_session_path, method: :delete, 
+                     form: { class: 'inline' },
+                     class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+                <!-- ログアウトアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ログアウト</span>
+              <% end %>
             <% else %>
-              <!-- 【修正】ログアウト時は「新規登録」「ログイン」ボタンを表示 -->
-              <%= link_to '新規登録', new_user_registration_path, class: 'inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition duration-200' %>
-              <%= link_to 'ログイン', new_user_session_path, class: 'inline-block px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white font-semibold rounded transition duration-200' %>
+              <!-- ログアウト時は「新規登録」「ログイン」ボタンを表示 -->
+              <%= link_to new_user_registration_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- 新規登録アイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">新規登録</span>
+              <% end %>
+
+              <%= link_to new_user_session_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- ログインアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ログイン</span>
+              <% end %>
             <% end %>
           
           <!-- 新規登録ページの場合 -->
           <% elsif controller_path == 'users/registrations' && action_name == 'new' %>
-            <!-- トップページボタン：px-4 py-2 で余白、bg-blue-500 で青色背景、hover:bg-blue-600 でホバー時に濃い青色、text-white で白文字、font-semibold で太字、rounded で角丸、transition duration-200 でアニメーション、inline-block で表示 -->
-            <%= link_to 'トップページ', root_path, class: 'inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition duration-200' %>
-          
-          <!-- ログインページの場合（トップページボタンを表示） -->
+            <!-- ホームボタンを表示 -->
+            <%= link_to root_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+              <!-- ホームアイコン(SVG) -->
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+              <!-- ボタンのテキスト -->
+              <span class="text-xs mt-1">ホーム</span>
+            <% end %>
+
+          <!-- ログインページの場合 -->
           <% elsif controller_path == 'users/sessions' && action_name == 'new' %>
-            <!-- トップページボタン：px-4 py-2 で余白、bg-blue-500 で青色背景、hover:bg-blue-600 でホバー時に濃い青色、text-white で白文字、font-semibold で太字、rounded で角丸、transition duration-200 でアニメーション、inline-block で表示 -->
-            <%= link_to 'トップページ', root_path, class: 'inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition duration-200' %>
- 
-          <!-- 【修正】設定ページの場合 -->
-          <% elsif controller_path == 'users/registrations' && action_name == 'edit' %>
-            <!-- 【修正】トップページボタンを追加（ロゴでも遷移できるが、明示的なボタンも用意） -->
-            <%= link_to 'トップページ', root_path, class: 'inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition duration-200' %>
-            <!-- ログアウトボタン：button_to を使用して DELETE メソッドで送信、method: :delete で DELETE リクエストを送信、form_class で form 要素にスタイルを適用、class でボタン自体にスタイルを適用 -->
-            <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, form_class: 'inline-block', class: 'px-4 py-2 bg-red-500 hover:bg-red-600 text-white font-semibold rounded transition duration-200 cursor-pointer' %>
+            <!-- ホームボタンを表示 -->
+            <%= link_to root_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+              <!-- ホームアイコン(SVG) -->
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+              <!-- ボタンのテキスト -->
+              <span class="text-xs mt-1">ホーム</span>
+            <% end %>
           
-          <!-- 【修正】記録ページの場合 -->
-          <% elsif controller_name == 'water_intakes' && action_name == 'index' %>
-            <!-- 【修正】トップページボタンを追加（ロゴでも遷移できるが、明示的なボタンも用意） -->
-            <%= link_to 'トップページ', root_path, class: 'inline-block px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition duration-200' %>
-            <!-- 設定ボタン：inline-block で表示、px-4 py-2 で余白、bg-gray-500 で灰色背景、hover:bg-gray-600 でホバー時に濃い灰色、text-white で白文字、font-semibold で太字、rounded で角丸、transition duration-200 でアニメーション -->
-            <%= link_to '設定', edit_user_registration_path, class: 'inline-block px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white font-semibold rounded transition duration-200' %>
-            <!-- ログアウトボタン：button_to を使用して DELETE メソッドで送信、method: :delete で DELETE リクエストを送信、form_class で form 要素にスタイルを適用、class でボタン自体にスタイルを適用 -->
-            <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, form_class: 'inline-block', class: 'px-4 py-2 bg-red-500 hover:bg-red-600 text-white font-semibold rounded transition duration-200 cursor-pointer' %>
+          <!-- 設定ページの場合 -->
+          <% elsif controller_path == 'users/registrations' && action_name == 'edit' %>
+            <!-- ログアウトボタンを表示 -->
+            <%= button_to destroy_user_session_path, method: :delete, 
+                   form: { class: 'inline' },
+                   class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+              <!-- ログアウトアイコン(SVG) -->
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              <!-- ボタンのテキスト -->
+              <span class="text-xs mt-1">ログアウト</span>
+            <% end %>
+          
+          <!-- 記録ページの場合 -->
+          <% elsif controller_path == 'water_intakes' && action_name == 'index' %>
+            <!-- ログアウトボタンを表示 -->
+            <%= button_to destroy_user_session_path, method: :delete, 
+                   form: { class: 'inline' },
+                   class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+              <!-- ログアウトアイコン(SVG) -->
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              <!-- ボタンのテキスト -->
+              <span class="text-xs mt-1">ログアウト</span>
+            <% end %>
+
+          <!-- カレンダーページの場合 -->
+          <% elsif controller_path == 'calendars' && action_name == 'index' %>
+            <!-- ログアウトボタンを表示 -->
+            <%= button_to destroy_user_session_path, method: :delete, 
+                   form: { class: 'inline' },
+                   class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+              <!-- ログアウトアイコン(SVG) -->
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              <!-- ボタンのテキスト -->
+              <span class="text-xs mt-1">ログアウト</span>
+            <% end %>
+
+          <!-- お問い合わせページの場合 -->
+          <% elsif controller_name == 'static_pages' && action_name == 'contact' %>
+            <% if user_signed_in? %>
+              <!-- ログイン中の場合は「ログアウト」ボタンを表示 -->
+              <%= button_to destroy_user_session_path, method: :delete, 
+                     form: { class: 'inline' },
+                     class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+                <!-- ログアウトアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ログアウト</span>
+              <% end %>
+            <% else %>
+              <!-- ログアウト時は「ホーム」ボタンを表示 -->
+              <%= link_to root_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- ホームアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ホーム</span>
+              <% end %>
+            <% end %>
+
+          <!-- 利用規約ページの場合 -->
+          <% elsif controller_name == 'static_pages' && action_name == 'terms' %>
+            <% if user_signed_in? %>
+              <!-- ログイン中の場合は「お問い合わせ」「ログアウト」ボタンを表示 -->
+              <%= link_to contact_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- お問い合わせアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">お問い合わせ</span>
+              <% end %>
+              
+              <%= button_to destroy_user_session_path, method: :delete, 
+                     form: { class: 'inline' },
+                     class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+                <!-- ログアウトアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ログアウト</span>
+              <% end %>
+            <% else %>
+              <!-- ログアウト時は「新規登録」「ホーム」ボタンを表示 -->
+              <%= link_to new_user_registration_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- 新規登録アイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">新規登録</span>
+              <% end %>
+              
+              <%= link_to root_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- ホームアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ホーム</span>
+              <% end %>
+            <% end %>
+
+          <!-- プライバシーポリシーページの場合 -->
+          <% elsif controller_name == 'static_pages' && action_name == 'privacy' %>
+            <% if user_signed_in? %>
+              <!-- ログイン中の場合は「お問い合わせ」「ログアウト」ボタンを表示 -->
+              <%= link_to contact_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- お問い合わせアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">お問い合わせ</span>
+              <% end %>
+              
+              <%= button_to destroy_user_session_path, method: :delete, 
+                     form: { class: 'inline' },
+                     class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer' do %>
+                <!-- ログアウトアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ログアウト</span>
+              <% end %>
+            <% else %>
+              <!-- ログアウト時は「新規登録」「ホーム」ボタンを表示 -->
+              <%= link_to new_user_registration_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- 新規登録アイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">新規登録</span>
+              <% end %>
+              
+              <%= link_to root_path, class: 'flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200' do %>
+                <!-- ホームアイコン(SVG) -->
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                </svg>
+                <!-- ボタンのテキスト -->
+                <span class="text-xs mt-1">ホーム</span>
+              <% end %>
+            <% end %>
           <% end %>
         </div>
       </div>
     </header>
+ 
+   <!-- フラッシュメッセージ表示エリア -->
+    <% if flash.any? %>
+      <div class="container mx-auto px-4 mt-4">
+        <% flash.each do |type, message| %>
+          <!-- フラッシュメッセージの種類に応じて色を変える -->
+          <div class="<%= type == 'notice' ? 'bg-green-100 border-green-400 text-green-700' : 'bg-red-100 border-red-400 text-red-700' %> px-4 py-3 rounded relative mb-4" role="alert">
+            <!-- メッセージ本文 -->
+            <span class="block sm:inline"><%= message %></span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
 
-    <!-- Flash メッセージを表示 -->
-    <%= render 'shared/flash_message' %>
+    <!-- ボトムナビゲーションの有無で余白を変える -->
+    <main class="<%= show_bottom_navigation? ? 'pb-16' : 'pb-4' %>">
+      <%= yield %>
+    </main>
 
-    <!-- 各ページの内容を表示(各コントローラーのビューが挿入される) -->
-    <%= yield %>
+    <!-- ボトムナビゲーションを条件付きで表示 -->
+    <% if show_bottom_navigation? %>
+      <%= render 'shared/bottom_navigation' %>
+    <% end %>
+
+    <!-- フッターエリア -->
+    <footer class="bg-pure-black text-pure-white py-4 text-center">
+      <!-- コンテナで中央寄せ、余白設定 -->
+      <div class="container mx-auto px-4">
+        <!-- ログイン状態によってリンクの表示・非表示を切り替え -->
+        <% if user_signed_in? %>
+          <!-- 【修正】記録画面と設定画面では非表示にする -->
+          <% unless (controller_path == 'water_intakes' && action_name == 'index') || (controller_path == 'users/registrations' && action_name == 'edit') %>
+            <!-- ログイン中の場合のみリンクを表示 -->
+            <div class="flex flex-col items-center space-y-2">
+              <!-- 利用規約リンク -->
+              <%= link_to "利用規約", terms_path, class: "hover:text-brand-orange transition duration-200" %>
+              <!-- プライバシーポリシーリンク -->
+              <%= link_to "プライバシーポリシー", privacy_path, class: "hover:text-brand-orange transition duration-200" %>
+              <!-- お問い合わせリンク -->
+              <%= link_to "お問い合わせ", contact_path, class: "hover:text-brand-orange transition duration-200" %>
+          </div>
+        <% end %>
+      <% end %> 
+        <!-- コピーライト表示(常に表示・年号は自動更新)  -->
+        <p class="mt-4 text-sm text-gray-400">© <%= Time.current.year %> Mizumo. All rights reserved.</p>
+      </div>
+    </footer>
   </body>
 </html>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,0 +1,88 @@
+<%# 【修正】app/views/shared/_bottom_navigation.html.erb %>
+<%# 全画面で使い回す『共通のフッター(画面下部のナビゲーション)』 %>
+
+<%# ボトムナビゲーション全体のコンテナ(画面下部に固定) %>
+<%# 背景色を紺、テキスト色を白に変更 %>
+<nav class="fixed bottom-0 left-0 right-0 bg-brand-navy border-t shadow-lg z-50">
+  
+  <%# ナビゲーション内のリンクを横並びにするコンテナ(justify-between で均等配置、py-2 で上下の余白を調整) %>
+  <div class="flex justify-between items-center py-2 px-2">
+    
+    <%# ログイン状態で表示内容を切り替える %>
+    <% if user_signed_in? %>
+      
+      <%# --- ログイン済みの場合 --- %>
+      
+      <%# 【修正】ホームリンク(テキスト色を白) %>
+      <%= link_to root_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+        </svg>
+        <span class="text-xs mt-1">ホーム</span>
+      <% end %>
+      
+      <%# 【修正】設定リンク%>
+      <%= link_to edit_user_registration_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+        <span class="text-xs mt-1">設定</span>
+      <% end %>
+      
+      <%# 【修正】記録リンク %>
+      <%= link_to water_intakes_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        <span class="text-xs mt-1">記録</span>
+      <% end %>
+
+      <%# 【修正】カレンダーリンク %>
+      <%= link_to calendar_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        <span class="text-xs mt-1">カレンダー</span>
+      <% end %>
+      
+    <% else %>
+
+      <%# --- ログアウト時の場合 --- %>
+
+      <%# 【修正】お問い合わせリンク %>
+      <%= link_to contact_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <%# 【修正】お問い合わせアイコン(SVG) %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <%# 【修正】アイコンのパス %>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+        <%# 【修正】リンクのテキスト %>
+        <span class="text-xs mt-1">お問い合わせ</span>
+      <% end %>
+      
+      <%# 【修正】利用規約リンク %>
+      <%= link_to terms_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <%# 【修正】利用規約アイコン(SVG) %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <%# 【修正】アイコンのパス %>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        <%# 【修正】リンクのテキスト %>
+        <span class="text-xs mt-1">利用規約</span>
+      <% end %>
+      
+      <%# 【修正】プライバシーポリシーリンク %>
+      <%= link_to privacy_path, class: "flex flex-col items-center justify-center text-pure-white hover:text-brand-orange active:scale-95 active:opacity-70 transition duration-200 flex-1 min-w-0 py-2" do %>
+        <%# 【修正】プライバシーポリシーアイコン(SVG) %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <%# 【修正】アイコンのパス %>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        </svg>
+        <%# 【修正】リンクのテキスト %>
+        <span class="text-xs mt-1">プライバシー</span>
+      <% end %>
+      
+    <% end %>
+  </div>
+</nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,49 +1,66 @@
-<%# 【修正】app/views/shared/_header.html.erb %>
-<%# ヘッダー全体を白背景・影付きで表示 %>
-<header class="bg-white shadow-md">
+<%# app/views/shared/_header.html.erb %>
+<%# 全画面で使い回す『共通のヘッダー(画面上部のナビゲーション)』 %>
+
+<%# 【修正】背景色を紺、テキスト色を白に変更 %>
+<header class="bg-brand-navy text-pure-white shadow-lg">
   <%# コンテナ: 中央寄せ、左右の余白、上下の余白、要素を横並び・左右に配置 %>
   <div class="container mx-auto px-4 py-3 flex items-center justify-between">
     
-    <%# === ロゴ（左側） === %>
-    <%# ロゴを囲むコンテナ: 要素を横並びで中央揃え %>
-    <div class="flex items-center">
-      <%# ルートパス（/）へのリンク: 要素を横並びで中央揃え %>
-      <%= link_to root_path, class: "flex items-center" do %>
-        <%# カタカナでロゴを表示: テキストサイズ大、太字、グレー色 %>
-        <span class="text-2xl font-bold text-gray-800">ミズモ</span>
-      <% end %>
-    </div>
-
-    <%# === ナビゲーションメニュー（右側） === %>
-    <%# ナビゲーション: 要素を横並び・中央揃え、要素間に余白 %>
-    <nav class="flex items-center space-x-4">
+      <%# === ロゴ（左側） === %>
+      <div class="flex items-center">
+        <%# 【修正】ルートパス（/）へのリンク: テキストサイズ大、太字、白色 %>
+        <%= link_to root_path, class: "text-2xl font-bold text-pure-white hover:text-brand-orange transition duration-200" do %>
+          ミズモ
+        <% end %>
+      </div>
       
-      <%# === ログイン状態の判定 === %>
-      <%# user_signed_in? は Devise が提供するメソッド（ログイン済みなら true） %>
-      <% if user_signed_in? %>
+      <%# === ナビゲーションメニュー（右側） === %>
+      <%# 【修正】ナビゲーション: 要素を横並び・中央揃え、要素間に余白 %>
+      <nav class="flex items-center space-x-4">
         
-        <%# --- ログイン済みの場合 --- %>
-        
-        <%# 「記録」リンク: ルートパス（/）へ遷移 %>
-        <%= link_to "記録", root_path, class: "text-gray-600 hover:text-gray-800 font-semibold transition duration-200" %>
-        
-        <%# 「設定」リンク: ユーザー編集ページ（/users/:id/edit）へ遷移 %>
-        <%= link_to "設定", edit_user_path(current_user), class: "text-gray-600 hover:text-gray-800 font-semibold transition duration-200" %>
-        
-        <%# 「ログアウト」ボタン: DELETE メソッドでログアウト処理を実行 %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded font-semibold transition duration-200" %>
-        
-      <% else %>
-        
-        <%# --- 未ログインの場合 --- %>
-        
-        <%# 「ログイン」リンク: ログインページ（/users/sign_in）へ遷移 %>
-        <%= link_to "ログイン", new_user_session_path, class: "text-gray-600 hover:text-gray-800 font-semibold transition duration-200" %>
-        
-        <%# 「新規登録」リンク: 新規登録ページ（/users/sign_up）へ遷移 %>
-        <%= link_to "新規登録", new_user_registration_path, class: "bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded font-semibold transition duration-200" %>
-        
-      <% end %>
-    </nav>
+        <%# === ログイン状態の判定 === %>
+        <% if user_signed_in? %>
+          
+          <%# --- ログイン済みの場合 --- %>
+          
+          <%# 【修正】ホームリンク(アイコン上、文字下) %>
+          <%= link_to root_path, class: "flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            <span class="text-xs mt-1">ホーム</span>
+          <% end %>
+          
+          <%# 【修正】ログアウトボタン(アイコン上、文字下) %>
+          <%= button_to destroy_user_session_path, method: :delete, class: "flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200 bg-transparent border-0 p-0 cursor-pointer" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+            </svg>
+            <span class="text-xs mt-1">ログアウト</span>
+          <% end %>
+          
+        <% else %>
+          
+          <%# --- ログアウト時の場合 --- %>
+          
+          <%# 【修正】新規登録ボタン(アイコン上、文字下) %>
+          <%= link_to new_user_registration_path, class: "flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+            </svg>
+            <span class="text-xs mt-1">新規登録</span>
+          <% end %>
+          
+          <%# 【修正】ログインボタン(アイコン上、文字下) %>
+          <%= link_to new_user_session_path, class: "flex flex-col items-center text-pure-white hover:text-brand-orange transition duration-200" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+            </svg>
+            <span class="text-xs mt-1">ログイン</span>
+          <% end %>
+          
+        <% end %>
+      </nav>
+    </div>
   </div>
 </header>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,0 +1,9 @@
+<!-- 【仮追加】app/views/static_pages/contact.html.erb -->
+<!-- 静的なページ：お問い合わせページの見た目（フォームや連絡先の案内） -->
+<!-- コンテナ全体のレイアウト設定 -->
+<div class="container mx-auto px-4 py-8">
+  <!-- ページタイトル -->
+  <h1 class="text-2xl font-bold mb-4">お問い合わせ</h1>
+  <!-- 準備中メッセージ -->
+  <p>お問い合わせページです。(準備中)</p>
+</div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,9 @@
+<!-- 【仮追加】app/views/static_pages/privacy.html.erb  -->
+<!-- 静的なページ：プライバシーポリシーが書かれた文章ページ -->
+<!-- コンテナ全体のレイアウト設定 -->
+<div class="container mx-auto px-4 py-8">
+  <!-- ページタイトル -->
+  <h1 class="text-2xl font-bold mb-4">プライバシーポリシー</h1>
+  <!-- 準備中メッセージ -->
+  <p>プライバシーポリシーページです。(準備中)</p>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,9 @@
+<!-- 【仮追加】app/views/static_pages/terms.html.erb -->
+<!-- コンテナ全体のレイアウト設定 -->
+<!-- 静的なページ：利用規約が書かれた文章ページ -->
+<div class="container mx-auto px-4 py-8">
+  <!-- ページタイトル -->
+  <h1 class="text-2xl font-bold mb-4">利用規約</h1>
+  <!-- 準備中メッセージ -->
+  <p>利用規約ページです。(準備中)</p>
+</div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -134,8 +134,7 @@ Rails.application.configure do
   # Renderのホストを許可
   config.hosts << 'mizumo.onrender.com'
   # 【追加】Renderのドメインを許可
-  config.hosts << "mizumo-db-neon.onrender.com"
-
+  config.hosts << 'mizumo-db-neon.onrender.com'
 
   # 開発段階では全て許可（本番では削除推奨）
   # config.hosts.clear

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config/routes.rb
-# Rails アプリケーションのルーティング（URL とコントローラーの紐付け）を設定するファイル
+# 「URL」と「処理（Controller）」をつなぐ仲介役
 Rails.application.routes.draw do
   # Devise のルーティングを設定（カスタマイズしたコントローラを使用）
   devise_for :users, controllers: {
@@ -31,6 +31,16 @@ Rails.application.routes.draw do
     end
   end
 
-  # 【削除】ユーザー編集ページのルート（Devise の registrations で管理されるため不要）
+  # ユーザー編集ページのルート（Devise の registrations で管理されるため不要）
   # resources :users, only: [:edit, :update]
+
+  # 【追加】カレンダー画面（/calendar）のルーティング
+  get 'calendar', to: 'calendars#index'
+
+  # 【追加】お問い合わせページ
+  get 'contact', to: 'static_pages#contact'
+  # 【追加】利用規約ページ
+  get 'terms', to: 'static_pages#terms'
+  # 【追加】プライバシーポリシーページ
+  get 'privacy', to: 'static_pages#privacy'
 end

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,5 +1,5 @@
-//【追加】config/tailwind.config.js
-// Tailwind CSS の設定ファイル
+// config/tailwind.config.js
+// Webサイトのデザインのルール（色やフォント、画面サイズなど）をカスタマイズするための「Tailwind CSSの設定ファイル」
 module.exports = {
   // スキャン対象のファイルを指定
   content: [
@@ -16,7 +16,23 @@ module.exports = {
   // テーマのカスタマイズ
   theme: {
     extend: {
-      // ここにカスタムテーマを追加
+      // 【変更】ここにカスタムテーマを追加
+      colors: {
+        // ① 背景（ベース）
+        'ivory': '#FDFBF7',
+        
+        // ② ヘッダー・フッター背景色：ネイビー
+        'brand-navy': '#12436D',
+        
+        // ③ 文字色（テキスト）
+        'charcoal': '#222222',
+        
+        // ④ アクセント
+        'brand-orange': '#D85F00',
+
+        // ⑤ ヘッダー・フッターの文字・アイコン色
+        'pure-white': '#FFFFFF',
+      }
     },
   },
   


### PR DESCRIPTION
## 概要
### 1. 以下のページを仮実装(今後コンテンツを追加予定)
- 利用規約ページ(`/terms`)
- プライバシーポリシーページ(`/privacy`)
- お問い合わせページ(`/contact`)
- カレンダーページ(`/calendar`)

### 2. ボトムナビゲーションの実装
- 全ページ共通のヘッダーをパーシャルとして実装
- ログイン状態に応じて表示内容が変わるボトムナビゲーションを実装
  - ログイン前（ホーム、お問い合わせ、利用規約、プライバシーポリシー画面のみ）:お問い合わせ、利用規約、プライバシーポリシー
  - ログイン後:ホーム、設定、記録、カレンダー
- アイコンを上部、文字を下記に表示 

### 3. ヘッダーの実装
- 全画面共通で、左上に `ミズモ` のロゴを表示します。
- 右上には、画面とログイン状態に応じて以下のボタンを表示します:

| 画面 | ログイン前 | ログイン後 |
|------|-----------|-----------|
| ホーム | 新規登録、ログイン | ログアウト |
| お問い合わせ、新規登録、ログイン | ホーム | - |
| 利用規約、プライバシーポリシー | 新規登録、ホーム | - |
| 記録、設定、カレンダー | - | ログアウト |

### 4. カスタムカラー設定
- Tailwind CSSに独自のカラーパレット(紺色、オレンジ、アイボリーなど)を追加

---

## 動作確認
以下の画面で動作確認を行いました。

**スクリーンショット：**
- [x] ホーム画面(`/`)
- ログイン前
![ホーム画面ログイン前](https://gyazo.com/1590087435c56e8da3c2cb815db75a8b.png)

- ログイン後
![ホーム画面ログイン後](https://gyazo.com/160767317b64e2e2fc6d90d38c893456.png)


- [x] お問い合わせ画面(`/contact`)
![お問い合わせ画面](https://gyazo.com/fee38a7a4b10d9e67ad0ab7b0fdddc05.png)


- [x] 利用規約画面(`/terms`)
![利用規約画面](https://gyazo.com/16b7cf8a0f51bfc657ba7fdb4a03a412.png)


- [x] プライバシーポリシー画面(`/privacy`)
![プライバシーポリシー画面](https://gyazo.com/efcb90912c29e102855e513d988d4bea.png)


- [x] 新規登録画面(`/sign_up`)
![新規登録画面](https://gyazo.com/0588348dcaaf6b11aa9ce9334fb37254.png)


- [x] ログイン画面(`/sign_in`)
![ログイン画面](https://gyazo.com/d41263410d936af3d895493c3b8f5f91.png)


- [x] 設定画面(`/users/edit`)
![設定画面](https://gyazo.com/c7d3fd52e4bfdff540fff0e2b1653658.png)


- [x] 記録画面(`/water_intakes`)
![記録画面](https://gyazo.com/c1fc96d6003e6662ab5b804d84c93c1e.png)


- [x] カレンダー画面(`/calendar`)
![カレンダー画面](https://gyazo.com/d3f5d9ee40b64b1719b384ec275e4f27.png)


---

Closes #65